### PR TITLE
升级到1.0.9版本，添加了AddGlobalHook、Authorize装饰器支持设置到控制器上

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@wangminghua/koa-restful",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Koa Restful 是一个基于 Koa 框架的 Restful Web API 插件开源库，使用 TypeScript 构建。它旨在提供一种轻量、高效、易用的方式来构建 RESTful 风格的后端服务。",
     "main": "./dist/index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "run-di": "node ./dist-example/di.js",
         "run-di-ts": "ts-node ./src-example/di.ts",
         "run-openapi-ts": "ts-node ./src-example/openapi.ts",
+        "run-extra-ts": "ts-node ./src-example/extra.ts",
         "docs:build": "vitepress build docs",
         "docs:serve": "vitepress serve docs"
     },

--- a/src-example/extra.ts
+++ b/src-example/extra.ts
@@ -1,0 +1,87 @@
+import { Context } from 'koa'
+import { Authorize, Controller, FromHeader, FromQuery, FromRoute, HttpGet } from '../src'
+import { AddCookieAuthentication, AddSwaggerUI, bootstrap } from '../src-extra'
+
+// 测试类型
+type TestModel = { name: string; value: string }
+
+/**
+ * 创建 GET 请求控制器（仅支持类）
+ */
+@Controller()
+class GetController {
+    /**
+     * 返回一个字符串
+     * @returns
+     */
+    @HttpGet()
+    test1(): string {
+        return `GetController test1 = ${new Date().toLocaleTimeString()}`
+    }
+
+    // 获取查询参数
+    @HttpGet()
+    test2(@FromQuery() name: string): string {
+        return `GetController test2 = ${new Date().toLocaleTimeString()} name = ${name}`
+    }
+
+    // 获取路径参数
+    @HttpGet('test3/:id')
+    test3(@FromRoute() id: string): string {
+        return `GetController test3 = ${new Date().toLocaleTimeString()} id = ${id}`
+    }
+
+    // 读取路径参数和查询参数
+    @HttpGet('test4/:id')
+    test4(@FromRoute() id: string, @FromQuery() name: string): string {
+        return `GetController test4 = ${new Date().toLocaleTimeString()} id = ${id} name = ${name}`
+    }
+
+    // 第一个参数默认为Koa Context
+    @HttpGet('test5/:id')
+    test5(ctx: Context, @FromRoute() id: string, @FromQuery() name: string): string {
+        return `GetController test5 = ${new Date().toLocaleTimeString()} id = ${id} name = ${name} ip = ${ctx.request.ip}`
+    }
+
+    // 方法参数名称不匹配时，指定从固定参数读取
+    @HttpGet('test6/:id')
+    test6(@FromRoute('id') id2: string): string {
+        return `GetController test6 = ${new Date().toLocaleTimeString()} id = ${id2}`
+    }
+
+    // 从请求头读取token参数
+    @HttpGet()
+    test7(@FromHeader() token: string): string {
+        return `GetController test7 = ${new Date().toLocaleTimeString()} token = ${token}`
+    }
+    // 强制路由转换 为 test8-2
+    @HttpGet('test8-2')
+    test8(): string {
+        return `GetController test8 = ${new Date().toLocaleTimeString()}`
+    }
+}
+
+/**
+ * 此控制器需要身份认证后访问
+ */
+@Authorize()
+@Controller()
+class AuthorizeController {
+    @HttpGet()
+    test1(): string {
+        return `GetController test1 = ${new Date().toLocaleTimeString()}`
+    }
+
+    // 获取查询参数
+    @HttpGet()
+    test2(@FromQuery() name: string): string {
+        return `GetController test2 = ${new Date().toLocaleTimeString()} name = ${name}`
+    }
+}
+
+AddSwaggerUI('src-example/extra.ts')
+AddCookieAuthentication({
+    secret: '12314asd45wqe',
+})
+
+bootstrap(3000)

--- a/src-example/extra.ts
+++ b/src-example/extra.ts
@@ -1,6 +1,24 @@
+import { AddGlobalHook, Authorize, Controller, FromHeader, FromQuery, FromRoute, HttpGet } from '@wangminghua/koa-restful'
+import { AddCookieAuthentication, AddSwaggerUI, bootstrap } from '@wangminghua/koa-restful/extra'
 import { Context } from 'koa'
-import { Authorize, Controller, FromHeader, FromQuery, FromRoute, HttpGet } from '../src'
-import { AddCookieAuthentication, AddSwaggerUI, bootstrap } from '../src-extra'
+
+AddGlobalHook(
+    async () => {
+        console.log('__GLOBAL_BEFORE_HOOK__')
+    },
+    {
+        hookType: 'globalBeforeHook',
+    }
+)
+
+AddGlobalHook(
+    async (ctx) => {
+        console.log('__GLOBAL_AFTER_HOOK__', ctx.body)
+    },
+    {
+        hookType: 'globalAfterHook',
+    }
+)
 
 // 测试类型
 type TestModel = { name: string; value: string }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,14 +22,14 @@ type KoaRestfulOptions = {
     logs?: boolean
 }
 
-function parseBeforeHooks(cls: Function, propertyKey: string): Array<Hook> {
+function parseBeforeHooks(cls: Function, propertyKey: string = '*'): Array<Hook> {
     const metadataKey = `${KEY_BEFORE_HOOK}${parsePropertyKey(propertyKey)}`
     const hooks = Reflect.getMetadata(metadataKey, cls) as Array<Hook> | undefined
 
     return hooks || []
 }
 
-function parseAfterHooks(cls: Function, propertyKey: string): Array<Hook> {
+function parseAfterHooks(cls: Function, propertyKey: string = '*'): Array<Hook> {
     const metadataKey = `${KEY_AFTER_HOOK}${parsePropertyKey(propertyKey)}`
     const hooks = Reflect.getMetadata(metadataKey, cls) as Array<Hook> | undefined
 
@@ -88,6 +88,7 @@ async function delayInit(options?: KoaRestfulOptions) {
                     //#endregion
 
                     try {
+                        debugger
                         //#region 调用前置钩子函数
                         const beforeHooks = parseBeforeHooks(controller.cls, propertyKey)
                         for (const hook of beforeHooks) {

--- a/src/restful/authorize.ts
+++ b/src/restful/authorize.ts
@@ -1,8 +1,17 @@
+import { AddDependency, ResolveDependencyFromUniqueId } from '@wangminghua/di'
 import { Context } from 'koa'
 import { Aspect } from '../utils/aspect'
 import { isNullOrUndefined } from '../utils/shared'
 
-const container = new Map<string, IAuthorization>()
+const uniqueId = '__koa_authorize_container__'
+
+AddDependency(new Map<string, IAuthorization>(), { uniqueId })
+
+// 从DI中加载数据
+function getContainer() {
+    return ResolveDependencyFromUniqueId(uniqueId) as Map<string, IAuthorization>
+}
+
 /**
  * 认证方式
  */
@@ -19,9 +28,10 @@ export interface IAuthorization {
  * @returns
  * @description 请注意，如果输入的是认证方案集合，则集合中的任意方案均可通过认证后。
  */
-export function Authorize(authenticationSchemes?: string | string[]): MethodDecorator {
+export function Authorize(authenticationSchemes?: string | string[]): ClassDecorator & MethodDecorator {
     return Aspect(
         async (ctx: Context) => {
+            const container = getContainer()
             if (container.size === 0) throw new Error('没有任何身份验证方案')
 
             // 没有指定身份认证方案，使用默认的方案进行认证
@@ -48,6 +58,7 @@ export function Authorize(authenticationSchemes?: string | string[]): MethodDeco
  * @param authorization 认证方式
  */
 export function AddAuthentication<TAuthorization extends IAuthorization>(authenticationScheme: string, authorization: TAuthorization) {
+    const container = getContainer()
     container.set(authenticationScheme, authorization)
     return authorization
 }

--- a/src/restful/authorize.ts
+++ b/src/restful/authorize.ts
@@ -47,7 +47,7 @@ export function Authorize(authenticationSchemes?: string | string[]): ClassDecor
             return Promise.reject()
         },
         {
-            hookType: '__BEFORE_HOOK__',
+            hookType: 'beforeHook',
         }
     )
 }

--- a/src/restful/index.ts
+++ b/src/restful/index.ts
@@ -1,12 +1,21 @@
-import { IScopeService, Lifecycle, SingletonScopeService, TransientScopeService } from '@wangminghua/di'
+import { AddDependency, IScopeService, Lifecycle, ResolveDependencyFromUniqueId, SingletonScopeService, TransientScopeService } from '@wangminghua/di'
 import { DefaultControllerOptions, KEY_ROUTE, KEY_ROUTE_PREFIX, isNullOrUndefined } from '../utils/shared'
 
 export * from './authorize'
 export * from './from-type'
 export * from './request-method'
 
+const uniqueId = '__koa_restful_controllers__'
 // 控制器列表
-const controllers = new Set<IScopeService>()
+AddDependency(new Set<IScopeService>(), { uniqueId })
+
+/**
+ * 获取 Controller 控制器列表
+ */
+export function getControllers() {
+    const controllers = ResolveDependencyFromUniqueId(uniqueId) as Set<IScopeService>
+    return controllers
+}
 
 /**
  * 控制器选项
@@ -59,7 +68,7 @@ export function Controller(route?: string, lifecycle?: ControllerOptions): Class
                 service = new TransientScopeService(target)
                 break
         }
-        options.enabled && controllers.add(service)
+        options.enabled && getControllers().add(service)
     }
 }
 
@@ -81,11 +90,4 @@ export function RoutePrefix(prefix: string): ClassDecorator {
  */
 export function AddController(target: Function, route?: string, lifecycle?: ControllerOptions) {
     Controller(route, lifecycle)(target)
-}
-
-/**
- * 获取 Controller 控制器列表
- */
-export function getControllers() {
-    return controllers
 }

--- a/src/utils/aspect.ts
+++ b/src/utils/aspect.ts
@@ -2,10 +2,7 @@
 // declare type PropertyDecorator = (target: Object, propertyKey: string | symbol) => void
 // declare type MethodDecorator = <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void
 // declare type ParameterDecorator = (target: Object, propertyKey: string | symbol | undefined, parameterIndex: number) => void
-import { Context } from 'koa'
-import { KEY_AFTER_HOOK, KEY_BEFORE_HOOK, parsePropertyKey } from './shared'
-
-export type Hook = (ctx: Context) => Promise<void>
+import { Hook, HookType, KEY_AFTER_HOOK, KEY_BEFORE_HOOK, parsePropertyKey } from './shared'
 /**
  * 切面选项
  */
@@ -13,32 +10,46 @@ type AspectOptions = {
     /**
      * 钩子类型
      */
-    hookType: typeof KEY_BEFORE_HOOK | typeof KEY_AFTER_HOOK
+    hookType: Extract<HookType, 'beforeHook' | 'afterHook'>
     /**
      * 定义元数据
      * @param target
      * @param propertyKey
      * @returns
      */
-    metadataHook?: (target: Object, propertyKey: string | symbol) => void
+    metadataHook?: (target: Object | Function, propertyKey: string | symbol) => void
 }
 /**
  * 切面函数
  */
 export function Aspect(hook: Hook, options?: AspectOptions): ClassDecorator & MethodDecorator {
     const { hookType, metadataHook } = {
-        hookType: KEY_BEFORE_HOOK,
+        hookType: 'beforeHook',
         ...options,
     } as AspectOptions
+
+    let hookTypeKey: typeof KEY_BEFORE_HOOK | typeof KEY_AFTER_HOOK
+    switch (hookType) {
+        case 'afterHook':
+            hookTypeKey = '__AFTER_HOOK__'
+            break
+        default:
+            hookTypeKey = '__BEFORE_HOOK__'
+            break
+    }
+
     return function (target: Object | Function, propertyKey: string | symbol = '*'): void {
         // 用于定义元数据
         metadataHook?.(target, propertyKey)
 
-        const metadataKey = `${hookType}${parsePropertyKey(propertyKey)}`
-        if (!Reflect.hasMetadata(metadataKey, target.constructor)) {
-            Reflect.defineMetadata(metadataKey, [], target.constructor)
+        const metadataKey = `${hookTypeKey}${parsePropertyKey(propertyKey)}`
+        // function 代表装饰器是一个ClassDecorator
+        const cls = typeof target === 'function' ? target : target.constructor
+
+        if (!Reflect.hasMetadata(metadataKey, cls)) {
+            Reflect.defineMetadata(metadataKey, [], cls)
         }
-        const hooks = Reflect.getMetadata(metadataKey, target.constructor) as Array<Hook>
+        const hooks = Reflect.getMetadata(metadataKey, cls) as Array<Hook>
         hooks.push(hook)
     }
 }

--- a/src/utils/aspect.ts
+++ b/src/utils/aspect.ts
@@ -25,12 +25,12 @@ type AspectOptions = {
 /**
  * 切面函数
  */
-export function Aspect(hook: Hook, options?: AspectOptions): MethodDecorator {
+export function Aspect(hook: Hook, options?: AspectOptions): ClassDecorator & MethodDecorator {
     const { hookType, metadataHook } = {
         hookType: KEY_BEFORE_HOOK,
         ...options,
     } as AspectOptions
-    return function (target: Object, propertyKey: string | symbol): void {
+    return function (target: Object | Function, propertyKey: string | symbol = '*'): void {
         // 用于定义元数据
         metadataHook?.(target, propertyKey)
 

--- a/src/utils/hook.ts
+++ b/src/utils/hook.ts
@@ -1,0 +1,34 @@
+import { AddDependency, ResolveDependencyFromUniqueId } from '@wangminghua/di'
+import { Hook, HookType, KEY_GLOBAL_AFTER_HOOK, KEY_GLOBAL_BEFORE_HOOK } from './shared'
+
+AddDependency([], { uniqueId: KEY_GLOBAL_BEFORE_HOOK })
+AddDependency([], { uniqueId: KEY_GLOBAL_AFTER_HOOK })
+
+/**
+ * 钩子选项
+ */
+type HookOptions = {
+    /**
+     * 钩子类型
+     */
+    hookType: Extract<HookType, 'globalBeforeHook' | 'globalAfterHook'>
+}
+
+/**
+ * 添加全局钩子函数
+ * @param hook 钩子
+ * @param options 选项
+ * @returns
+ */
+export function AddGlobalHook(hook: Hook, options: HookOptions): Hook {
+    const { hookType } = options
+    switch (hookType) {
+        case 'globalAfterHook':
+            ResolveDependencyFromUniqueId<Hook[]>(KEY_GLOBAL_AFTER_HOOK)?.push(hook)
+            break
+        default:
+            ResolveDependencyFromUniqueId<Hook[]>(KEY_GLOBAL_BEFORE_HOOK)?.push(hook)
+            break
+    }
+    return hook
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+export { Aspect } from './aspect'
+export { AddGlobalHook } from './hook'
+export { DefaultControllerOptions, Hook, HttpError, isNullOrUndefined, join } from './shared'

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -93,6 +93,24 @@ export function isNullOrUndefined(route: string | undefined | null) {
 }
 
 /**
+ * **Hook函数，执行顺序为：全局前置钩子 > 前置钩子 > 后置钩子 > 全局后置钩子**
+ */
+export type Hook = (ctx: Context) => Promise<void>
+
+/**
+ * **Hook类型，执行顺序为：全局前置钩子 > 前置钩子 > 后置钩子 > 全局后置钩子**
+ *
+ * 前置钩子=beforeHook
+ *
+ * 后置钩子=afterHook
+ *
+ * 全局前置钩子=globalBeforeHook
+ *
+ * 全局后置钩子=globalAfterHook
+ */
+export type HookType = 'beforeHook' | 'afterHook' | 'globalBeforeHook' | 'globalAfterHook'
+
+/**
  * 参数
  */
 export type TParam =

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -2,6 +2,15 @@ import { Lifecycle } from '@wangminghua/di'
 import { Context, Next } from 'koa'
 
 /**
+ * Global Before Hook KEY
+ */
+export const KEY_GLOBAL_BEFORE_HOOK = '__GLOBAL_BEFORE_HOOK__'
+/**
+ * Global After Hook KEY
+ */
+export const KEY_GLOBAL_AFTER_HOOK = '__GLOBAL_AFTER_HOOK__'
+
+/**
  * Before Hook KEY
  */
 export const KEY_BEFORE_HOOK = '__BEFORE_HOOK__'


### PR DESCRIPTION
1、添加了AddGlobalHook（全局钩子）
2、Authorize装饰器支持设置到控制器上
3、Aspect（切面装饰器）支持设置到控制器上，并添加了切面装饰器的导出
4、控制器列表和身份认证方法修改为 从 DI 中读取